### PR TITLE
fix: sdk:10.0 Dockerfile + IHistoryRepository guard on Migrate()

### DIFF
--- a/Dockerfile-service
+++ b/Dockerfile-service
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build-env
 ARG GITVERSION
 WORKDIR /app
 ARG GITVERSION

--- a/ServiceOuterInnerResourcePlugin/Core.cs
+++ b/ServiceOuterInnerResourcePlugin/Core.cs
@@ -26,6 +26,8 @@ using System.Threading;
 using Castle.MicroKernel.Registration;
 using Castle.Windsor;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microting.eForm.Dto;
 using Microting.eFormOuterInnerResourceBase.Infrastructure.Data;
 using Microting.eFormOuterInnerResourceBase.Infrastructure.Data.Factories;
@@ -129,7 +131,11 @@ public class Core : ISdkEventHandler
                 _dbContext = _dbContextHelper.GetDbContext();//.CreateDbContext(new[] { connectionString });
 
                 //_dbContextHelper = new DbContextHelper(connectionString);
-                _dbContext.Database.Migrate();
+                var historyRepo = _dbContext.GetService<IHistoryRepository>();
+                if (!historyRepo.Exists() || _dbContext.Database.GetPendingMigrations().Any())
+                {
+                    _dbContext.Database.Migrate();
+                }
 
                 _coreAvailable = true;
                 _coreStatChanging = false;


### PR DESCRIPTION
Upgrade build stage from sdk:9.0 to 10.0 and guard Database.Migrate() with IHistoryRepository.Exists() (Galera-safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)